### PR TITLE
Add rudimentary html structure and minimal css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .hg/
 resources/public/main.js
 resources/public/img/*
+resources/public/css/*

--- a/bin/build
+++ b/bin/build
@@ -7,6 +7,7 @@ lein fig:min
 cp resources/public/cljs-out/dev-main.js ../resources/public/main.js
 
 cp -R resources/public/img ../resources/public
+cp -R resources/public/css ../resources/public
 cd - || exit
 lein ring uberjar
 

--- a/client/resources/public/css/style.css
+++ b/client/resources/public/css/style.css
@@ -1,2 +1,23 @@
 /* some style */
 
+body {
+    font-family: Helvetica, sans-serif;
+}
+
+#match-info ul, main #player-hand, main #trick-cards {
+    list-style: none;
+    padding-left: 0;
+}
+
+#match-info ul li {
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+}
+
+main #player-hand li {
+    display: inline;
+}
+
+#trick-cards li div {
+    text-align: center;
+}

--- a/client/src/huutopussi_client/core.cljs
+++ b/client/src/huutopussi_client/core.cljs
@@ -117,32 +117,36 @@
     (str "Odottaa pelaajaa " (:next-player-name game))))
 
 (defn- show-match-status []
-  [:div
-   (condp = @(re-frame/subscribe [:state-change])
-     :finding-match [:p (str "Etsitään peliä pelaajalle " @(re-frame/subscribe [:player-name]))]
-     :matched [:p (str "Löytyi peli pelaajille: " (map :name (:players @(re-frame/subscribe [:match]))))]
-     :started (let [player-name @(re-frame/subscribe [:player-name])
-                    match @(re-frame/subscribe [:match])
-                    game @(re-frame/subscribe [:game])]
-                [:div
-                 [:p "Peli aloitettu joukkueilla: " (:teams match)]
-                 [:p (:current-round game) ". tikki, pisteet: " (:scores game)
-                     (when (:current-trump-suit game) (list ", " (get suits-fi (:current-trump-suit game)) "valtti"))]
-                 [:p (show-next-player player-name game) (show-possible-trumps game)]
-                 [:p "Käsikorttisi:"]
-                 (for [[index card] (doall (map-indexed vector (:cards game)))]
-                   ^{:key card}[:img {:on-click #(re-frame/dispatch [:player-card index])
-                                      :src (card-url card)
-                                      :width "170px"
-                                      :height "auto"}])
-                 [:p "Tikin kortit:"]
-                 [:div {:style {:display "flex"}}
-                  (for [{:keys [card player]} (:trick-cards game)]
-                    ^{:key card}[:div {:style {:width "170px"}}
-                                 [:span [:center player]]
-                                 [:img {:src (card-url card)
-                                        :width "100%"
-                                        :height "auto"}]])]]))])
+  (condp = @(re-frame/subscribe [:state-change])
+    :finding-match [:p (str "Etsitään peliä pelaajalle " @(re-frame/subscribe [:player-name]))]
+    :matched [:p (str "Löytyi peli pelaajille: " (map :name (:players @(re-frame/subscribe [:match]))))]
+    :started (let [player-name @(re-frame/subscribe [:player-name])
+                   match @(re-frame/subscribe [:match])
+                   game @(re-frame/subscribe [:game])]
+               (list
+                 [:section#match-info
+                  [:ul
+                   [:li "Peli aloitettu joukkueilla: " (:teams match)]
+                   [:li (:current-round game) ". tikki, pisteet: " (:scores game)
+                       (when (:current-trump-suit game) (list ", " (get suits-fi (:current-trump-suit game)) "valtti"))]
+                   [:li (show-next-player player-name game) (show-possible-trumps game)]]]
+                 [:main
+                  [:h2 "Käsikorttisi"]
+                  [:ul#player-hand
+                   (for [[index card] (doall (map-indexed vector (:cards game)))]
+                     ^{:key card} [:li
+                                   [:img {:on-click #(re-frame/dispatch [:player-card index])
+                                          :src (card-url card)
+                                          :width "170px"
+                                          :height "auto"}]])]
+                  [:h2 "Tikin kortit"]
+                  [:ul#trick-cards {:style {:display "flex"}}
+                   (for [{:keys [card player]} (:trick-cards game)]
+                     ^{:key card}[:li {:style {:width "170px"}}
+                                  [:div player]
+                                  [:img {:src (card-url card)
+                                         :width "100%"
+                                         :height "auto"}]])]]))))
 
 (defn- show-match-start []
   (let [player-name (atom "")]
@@ -177,8 +181,8 @@
 (defn events-view []
   (let [events @(re-frame/subscribe [:events])]
     (when events
-      [:div
-       [:p "Pelitapahtumat:"]
+      [:section#events
+       [:h2 "Pelitapahtumat"]
        [:ul
         (for [event (take 3 (reverse events))]
           ^{:key event} [:li (format-event event)])]])))


### PR DESCRIPTION
- Divide content in three top-level parts:
  - `section#match-info`
  - `main`
  - `section#events`
- Remove unnecessary sub-`divs`
- Prefer `ul` over `p` for listable content such as list of cards or list of match info items
- Use `h2` for content titles
- Use a sans-serif font
  
<img width="937" alt="Screenshot 2021-05-01 at 23 26 06" src="https://user-images.githubusercontent.com/845477/116794308-c3d16200-aad4-11eb-98c5-993b4c460c53.png">
